### PR TITLE
remove unfilled static hosting rows

### DIFF
--- a/.stoat/template.hbs
+++ b/.stoat/template.hbs
@@ -2,6 +2,6 @@
 | :--- | :--- | :--: | :-----: |
 {{#each plugins}}
 {{#if this.static_hosting}}
-| **{{#if this.metadata.name}}{{{ this.metadata.name }}}{{else}}{{ @key }}{{/if}}** | {{{ this.static_hosting.link_md }}} | {{ this.static_hosting.sha }} | {{#if this.static_hosting.status_md}}{{{ this.static_hosting.status_md }}}{{else}}🔄{{/if}} |
+{{#if this.static_hosting.status_md}}| **{{#if this.metadata.name}}{{{ this.metadata.name }}}{{else}}{{ @key }}{{/if}}** | {{{ this.static_hosting.link_md }}} | {{ this.static_hosting.sha }} | {{{ this.static_hosting.status_md }}} |{{/if}}
 {{/if}}
 {{/each}}

--- a/.stoat/template.hbs
+++ b/.stoat/template.hbs
@@ -2,6 +2,6 @@
 | :--- | :--- | :--: | :-----: |
 {{#each plugins}}
 {{#if this.static_hosting}}
-{{#if this.static_hosting.status_md}}| **{{#if this.metadata.name}}{{{ this.metadata.name }}}{{else}}{{ @key }}{{/if}}** | {{{ this.static_hosting.link_md }}} | {{ this.static_hosting.sha }} | {{{ this.static_hosting.status_md }}} |{{/if}}
+{{#if this.static_hosting.status_md ~}}| **{{#if this.metadata.name}}{{{ this.metadata.name }}}{{else}}{{ @key }}{{/if}}** | {{{ this.static_hosting.link_md }}} | {{ this.static_hosting.sha }} | {{{ this.static_hosting.status_md }}} |{{/if ~}}
 {{/if}}
 {{/each}}


### PR DESCRIPTION
In a PR like https://github.com/stoat-dev/stoat-action/pull/5 that doesn't touch the `/docs` path, it's a bit confusing to see the "pending" row which will never be triggered. It's probably better for now to just entirely exclude the row and only show it after it's generated.

Maybe it should also filter out empty tables?