### PR TITLE
fix cli yaml parsing

### DIFF
--- a/cli/__tests__/stoatActionHelpers.test.ts
+++ b/cli/__tests__/stoatActionHelpers.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 import fs from 'fs';
+import * as yaml from 'js-yaml';
 import path from 'path';
 
-import { addStoatActionToYaml } from '../src/helpers/init/configFileHelpers';
+import { addStoatActionToYaml, isOnPushOrPull } from '../src/helpers/init/configFileHelpers';
 
 describe('Add Stoat Action to YAML', () => {
   test('add action to build job', async () => {
@@ -21,5 +22,69 @@ describe('Add Stoat Action to YAML', () => {
     expect(
       addStoatActionToYaml({ name: 'build2', workflowFile: path.join(__dirname, 'expected-add-build.yaml') })
     ).toEqual(fs.readFileSync(path.join(__dirname, 'expected-add-build-and-build2.yaml')).toString());
+  });
+});
+
+describe('Check if we should add Stoat Action', () => {
+  test('on: push', async () => {
+    const workflowYaml = `on: push`;
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(true);
+  });
+
+  test('on: [push]', async () => {
+    const workflowYaml = `on: [push]`;
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(true);
+  });
+
+  test('on: 44', async () => {
+    const workflowYaml = `on: 44`;
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(false);
+  });
+
+  test('on: 44', async () => {
+    const workflowYaml = `
+on:
+  issues:
+    types:
+      - opened
+      - labeled`.trim();
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(false);
+  });
+
+  test('on: [fork, pull_request]', async () => {
+    const workflowYaml = `on: [fork, pull_request]`;
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(true);
+  });
+
+  test('on: push:', async () => {
+    const workflowYaml = `
+on:
+  push:`.trim();
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(true);
+  });
+
+  test('on issues and pull request:', async () => {
+    const workflowYaml = `
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  pull_request:`.trim();
+    const workflow: any = yaml.load(workflowYaml);
+
+    expect(isOnPushOrPull(workflow.on)).toEqual(true);
   });
 });

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoat",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Stoat CLI",
   "main": "dist/index.js",
   "files": [

--- a/cli/src/helpers/init/configFileHelpers.ts
+++ b/cli/src/helpers/init/configFileHelpers.ts
@@ -68,3 +68,15 @@ export function addStoatActionToYaml(job: GhJob): string {
 
   return yamlLines.join('\n');
 }
+
+export function isOnPushOrPull(on: any) {
+  if (String(on) === on) {
+    return on === 'pull_request' || on === 'push';
+  } else if (Array.isArray(on)) {
+    return on.includes('pull_request') || on.includes('push');
+  } else if (Object(on) === on) {
+    return 'pull_request' in on || 'push' in on;
+  } else {
+    return false;
+  }
+}

--- a/cli/src/helpers/init/stoatActionHelpers.ts
+++ b/cli/src/helpers/init/stoatActionHelpers.ts
@@ -78,7 +78,6 @@ function getRelevantJobs(dir: string): GhJob[] {
           }
         }
       } catch (e) {
-        console.error(e);
         console.warn(chalk.yellow(`Skipping workflow ${filename}: invalid YAML`));
       }
     }

--- a/cli/src/helpers/init/stoatActionHelpers.ts
+++ b/cli/src/helpers/init/stoatActionHelpers.ts
@@ -5,7 +5,7 @@ import * as yaml from 'js-yaml';
 import path from 'path';
 
 import { getGitRoot } from '../pathHelpers';
-import { addStoatActionToYaml } from './configFileHelpers';
+import { addStoatActionToYaml, isOnPushOrPull } from './configFileHelpers';
 
 export interface GhJob {
   name: string;
@@ -63,7 +63,7 @@ function getRelevantJobs(dir: string): GhJob[] {
       try {
         const workflow: any = yaml.load(contents);
 
-        if (('jobs' in workflow && 'on' in workflow && 'pull_request' in workflow.on) || 'push' in workflow.on) {
+        if ('jobs' in workflow && 'on' in workflow && isOnPushOrPull(workflow.on)) {
           for (const job in workflow.jobs) {
             if ('steps' in workflow.jobs[job]) {
               const steps = workflow.jobs[job].steps as any[];
@@ -78,6 +78,7 @@ function getRelevantJobs(dir: string): GhJob[] {
           }
         }
       } catch (e) {
+        console.error(e);
         console.warn(chalk.yellow(`Skipping workflow ${filename}: invalid YAML`));
       }
     }


### PR DESCRIPTION
resolves https://github.com/stoat-dev/stoat-action/issues/111

Turns out it wasn't actually invalid YAML, we were just not handling all possible versions of the `key:` setting. Now this should work for all valid and invalid workflow files (in the GH Workflow sense, not the YAML sense).