### PR TITLE
Wait for dev server to launch for the first time

### DIFF
--- a/action/src/stoatApiHelpers.ts
+++ b/action/src/stoatApiHelpers.ts
@@ -92,7 +92,11 @@ export const waitForShaToMatch = async (
     ++attempt;
     const response = await fetch(url);
     if (!response.ok) {
-      throw Error(`Failed to fetch server SHA: ${JSON.stringify(response, null, 2)}`);
+      if (response.status === 404) {
+        core.error(`Dev server is not up running yet`);
+      } else {
+        throw new Error(`Failed to fetch server SHA: ${response.status} - ${response.statusText}`);
+      }
     } else {
       const { sha: serverSha } = (await response.json()) as ShaResponse;
       core.info(`Repo SHA: ${repoSha} Server SHA: ${serverSha} Matches: ${repoSha === serverSha}`);
@@ -101,7 +105,7 @@ export const waitForShaToMatch = async (
         return serverBase;
       }
     }
-    core.info(`Waiting / retrying for server to be deployed...`);
+    core.info(`Waiting / retrying for latest change to be deployed...`);
     await new Promise((r) => setTimeout(r, perAttemptWaitingSeconds * 1000));
   }
 


### PR DESCRIPTION
When a new PR from the `stoat` repo is created, it takes a while for Vercel to launch a new dev server for the first time. When it happens, the current logic will fail immediately. This PR handles it by adding a special case for http code 404.
